### PR TITLE
Update for low power pin missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+# If you want to build the firmware blob, you need to download the STSW-IMG023 firmware package,
+# and agree to the terms. See https://www.st.com/en/embedded-software/stsw-img023.html#st-get-software
+# Download from https://www.st.com/content/ccc/resource/technical/software/application_sw/group0/43/1c/58/e9/46/a0/48/95/STSW-IMG023/files/STSW-IMG023.zip/jcr:content/translations/en.STSW-IMG023.zip
+# and start command with VL53L5CX_ULD_DIR=/path/to/unzipped/folder make vl_fw.bin
+
 # used to build a binary blob firmware file for the sensor's MCU
-VL53L5CX_ULD_DIR := /home/mark/Projects/vl53l5cx/VL53L5CX_ULD_driver_1.1.0
+VL53L5CX_ULD_DIR ?= /home/mark/Projects/vl53l5cx/VL53L5CX_ULD_driver_1.1.0
 
 vl53l5cx/%.mpy: vl53l5cx/%.py
 	mpy-cross -O2 $^

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This package provides a class that is (mostly) a straight port of the ST [Ultra 
 ![Range as colors demo](ttgo_vl53l5cx.png)
 
 The code has been tested with the VL53L5CX breakout board from [Pesky Products on Tindie](https://www.tindie.com/products/onehorse/vl53l5cx-ranging-camera/) using a [Pimoroni Tiny 2040](https://shop.pimoroni.com/products/tiny-2040) with both MicroPython (v1.16) and CircuitPython (v7.0) and a [LILYGO TTGO T-Display](http://www.lilygo.cn/prod_view.aspx?TypeId=50062&Id=1126&FId=t3:50062:3) using MicroPython (v1.17).
+Also with the [SparkFun Qwiic Mini ToF Imager](https://www.sparkfun.com/products/19013) on the [Adafruit QT Py ESP32-S2](https://www.adafruit.com/product/5325) using Circuitpython 8.2.3 and no Low Power Pin.
 
 ## Installation
 

--- a/examples/sparkfun_micro_vl53l5cx.py
+++ b/examples/sparkfun_micro_vl53l5cx.py
@@ -1,0 +1,66 @@
+### This is written for an RP2040 (Sparkfun Thing Plus), to provide a tab separated grid of data,
+### but should work with any single I2C board, otherwise change pins (check names under board in REPL).
+###
+### The low power enable/disable pin is not available on the mini / low-profile Sparkfun VL53L5CX
+### breakout https://www.sparkfun.com/products/19013 (if using low-power add LPN pins like examples)
+###
+### Designed to be visualised using processing (processing.org) as mentioned in the hookup guide
+### https://learn.sparkfun.com/tutorials/qwiic-tof-imager---vl53l5cx-hookup-guide
+### https://cdn.sparkfun.com/assets/learn_tutorials/2/0/0/2/SparkFun_VL53L5CX_3D_Depth_Map.zip
+
+
+# depends on 
+import board
+import busio
+
+from vl53l5cx.cp import VL53L5CXCP
+
+def make_sensor():
+
+    # lpn = low power pin, removed as using the micro VL53L5CX breakout without lpn
+    scl_pin, sda_pin = (board.SCL, board.SDA)
+
+    #i2c = busio.I2C(board.SCL1, board.SDA1,frequency=1_000_000)
+    i2c = busio.I2C(scl_pin, sda_pin, frequency=1_000_000)
+
+    return VL53L5CXCP(i2c)
+
+
+from vl53l5cx import DATA_TARGET_STATUS, DATA_DISTANCE_MM
+from vl53l5cx import STATUS_VALID, RESOLUTION_4X4, RESOLUTION_8X8
+
+
+def main():
+    tof = make_sensor()
+    tof.reset()
+
+    if not tof.is_alive():
+        raise ValueError("VL53L5CX not detected")
+
+    tof.init()
+
+    tof.resolution = RESOLUTION_8X8
+    grid = 7 # change to 3 if 4x4 grid
+
+    tof.ranging_freq = 4 # was 2, 4 felt intense!
+
+    tof.start_ranging({DATA_DISTANCE_MM, DATA_TARGET_STATUS})
+
+    while True:
+        if tof.check_data_ready():
+            results = tof.get_ranging_data()
+            distance = results.distance_mm
+            status = results.target_status
+
+            for i, d in enumerate(distance):
+                if status[i] == STATUS_VALID:
+                    print(d, end="")
+                else:
+                    print("0", end="")
+
+                print(",", end="")
+
+            print("")
+
+
+main()

--- a/tests/sensor_no_lpn.py
+++ b/tests/sensor_no_lpn.py
@@ -18,10 +18,10 @@ def make_sensor():
 
         i2c = I2C(0, scl=Pin(scl_pin, Pin.OUT), sda=Pin(sda_pin), freq=1_000_000)
 
-        tof = VL53L5CXMP(i2c, lpn=Pin(lpn_pin, Pin.OUT, value=1))
+        tof = VL53L5CXMP(i2c)
     else:
         import busio
-        from microcontroller import pin
+        #from microcontroller import pin
         from digitalio import DigitalInOut, Direction
 
         from vl53l5cx.cp import VL53L5CXCP
@@ -29,19 +29,14 @@ def make_sensor():
         ## import adafruit boards library for named pins
         import boards
         
-        ## Sparkfun RP2040 Thing Plus or other boards with one set of SCL/SDA pins, plus lpn from tiny2040 *untested*
-        scl_pin, sda_pin = (boards.SCL, boards.SDA, pin.GPIO28, pin.GPIO5)
+        # Sparkfun RP2040 Thing Plus or other boards with one set of SCL/SDA pins
+        scl_pin, sda_pin = (boards.SCL, boards.SDA)
         
         # Pimoroni TINY2040 coupled with VL53L5CX breakout with low-power-pin (lpn)
         #scl_pin, sda_pin = (pin.GPIO1, pin.GPIO0, pin.GPIO28, pin.GPIO5)
-        
 
         i2c = busio.I2C(scl_pin, sda_pin, frequency=1_000_000)
 
-        lpn = DigitalInOut(lpn_pin)
-        lpn.direction = Direction.OUTPUT
-        lpn.value = True
-
-        tof = VL53L5CXCP(i2c, lpn=lpn)
+        tof = VL53L5CXCP(i2c)
 
     return tof

--- a/tests/start_stop_no_lpn.py
+++ b/tests/start_stop_no_lpn.py
@@ -1,0 +1,40 @@
+from time import sleep
+
+from sensor_no_lpn import make_sensor
+
+from vl53l5cx import DATA_TARGET_STATUS, DATA_DISTANCE_MM
+from vl53l5cx import RESOLUTION_4X4, RESOLUTION_8X8
+
+
+def main():
+    tof = make_sensor()
+    tof.reset()
+    tof.init()
+
+    tof.ranging_freq = 15
+
+    for i in range(10):
+        if i & 0x1:
+            tof.resolution = RESOLUTION_4X4
+            length = 16
+        else:
+            tof.resolution = RESOLUTION_8X8
+            length = 64
+
+        tof.start_ranging({DATA_DISTANCE_MM, DATA_TARGET_STATUS})
+
+        while not tof.check_data_ready():
+            sleep(0.010)
+
+        results = tof.get_ranging_data()
+
+        assert(len(results.distance_mm) == length)
+        assert(len(results.target_status) == length)
+        assert(not results.motion_indicator)
+
+        tof.stop_ranging()
+
+    print("pass")
+
+
+main()

--- a/vl53l5cx/cp.py
+++ b/vl53l5cx/cp.py
@@ -50,11 +50,9 @@ class VL53L5CXCP(VL53L5CX):
             self.dev.write(buf)
 
     def reset(self):
-        if not self._lpn:
-            self.i2c.unlock()
-            #raise ValueError("no LPN pin provided")
-        else:
+        if self._lpn:
             self._lpn.value = False
             sleep(0.1)
             self._lpn.value = True
             sleep(0.1)
+        # ELSE: Rely on init function to do software reset

--- a/vl53l5cx/cp.py
+++ b/vl53l5cx/cp.py
@@ -51,9 +51,10 @@ class VL53L5CXCP(VL53L5CX):
 
     def reset(self):
         if not self._lpn:
-            raise ValueError("no LPN pin provided")
-
-        self._lpn.value = False
-        sleep(0.1)
-        self._lpn.value = True
-        sleep(0.1)
+            self.i2c.unlock()
+            #raise ValueError("no LPN pin provided")
+        else:
+            self._lpn.value = False
+            sleep(0.1)
+            self._lpn.value = True
+            sleep(0.1)

--- a/vl53l5cx/mp.py
+++ b/vl53l5cx/mp.py
@@ -23,11 +23,9 @@ class VL53L5CXMP(VL53L5CX):
         self.i2c.writeto_mem(self.addr, reg16, buf, addrsize=16)
 
     def reset(self):
-        if not self._lpn:
-            self.i2c.unlock()
-            #raise ValueError("no LPN pin provided")
-        else:
+        if self._lpn:
             self._lpn.value = False
             sleep_ms(100)
             self._lpn.value = True
             sleep_ms(100)
+        # ELSE: Rely on init function to do software reset

--- a/vl53l5cx/mp.py
+++ b/vl53l5cx/mp.py
@@ -24,9 +24,10 @@ class VL53L5CXMP(VL53L5CX):
 
     def reset(self):
         if not self._lpn:
-            raise ValueError("no LPN pin provided")
-
-        self._lpn.value(0)
-        sleep_ms(100)
-        self._lpn.value(1)
-        sleep_ms(100)
+            self.i2c.unlock()
+            #raise ValueError("no LPN pin provided")
+        else:
+            self._lpn.value = False
+            sleep_ms(100)
+            self._lpn.value = True
+            sleep_ms(100)


### PR DESCRIPTION
This closes #4 by removing the raised error if no low power pin defined.

There's a minor makefile change, maybe it's unnecessary, but also adds links for getting the ULD driver if rebuilding the binary blob.

~~I updated the MPY files and binary blob with version 1.3.9 of the ULD driver.~~